### PR TITLE
move faker to non dev-dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
         "laravel/sanctum": "^3.3",
         "laravel/tinker": "^2.8",
         "tightenco/ziggy": "^1.0",
+        "fakerphp/faker": "^1.9.1",
         "ext-openssl": "*"
     },
     "require-dev": {
-        "fakerphp/faker": "^1.9.1",
         "laravel/pint": "^1.0",
         "laravel/sail": "^1.18",
         "mockery/mockery": "^1.4.4",


### PR DESCRIPTION
Faker is needed in prod for the custom `admin:create-admin-users` artisan command