### PR TITLE
Fix shorts url creation (#15)

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -73,11 +73,17 @@ class Post extends Model
 
         if (str_contains($parsedUrl['path'], 'shorts')) {
 
-            $pattern = "/https:\/\/www\.youtube\.com\/shorts\/[a-zA-Z0-9_\-]*/";
+            $pattern = "/https:\/\/(www\.)?youtube\.com\/shorts\/[a-zA-Z0-9_\-]*/";
             preg_match($pattern, $url, $matches);
 
+            $host = $parsedUrl['host'];
+
+            if (!str_starts_with($host, 'www')) {
+                $host = 'www.' . $host;
+            }
+
             if ($matches) {
-                return $parsedUrl['scheme'] . '://' . $parsedUrl['host'] . $parsedUrl['path'];
+                return $parsedUrl['scheme'] . '://' . $host . $parsedUrl['path'];
             }
         }
 

--- a/tests/Unit/Post/SetOriginalUrlTest.php
+++ b/tests/Unit/Post/SetOriginalUrlTest.php
@@ -8,6 +8,7 @@ use Tests\TestCase;
 class SetOriginalUrlTest extends TestCase
 {
     private string $expectedNormalYoutubeUrl = 'https://www.youtube.com/watch?v=0jYQ58e1yXs';
+    private string $expectedShortsYoutubeUrl = 'https://www.youtube.com/shorts/D4u-BW_YgPA';
     private string $expectedNormalYoutubeUrlWithTimestamp = 'https://www.youtube.com/watch?v=0jYQ58e1yXs&t=101';
 
     /**
@@ -114,5 +115,92 @@ class SetOriginalUrlTest extends TestCase
         $post->setOriginalUrl($originalYouTubeUrlWithTimestamp);
 
         $this->assertEquals($this->expectedNormalYoutubeUrlWithTimestamp, $post->original_url);
+    }
+
+    /**
+     * Tests if a shorts YouTube video url gets parsed correctly
+     * (https://www.youtube.com/shorts/D4u-BW_YgPA)
+     *
+     * @test
+     */
+    public function set_original_url_sets_correct_url_with_shorts_youtube_video_url(): void
+    {
+        $originalYouTubeUrl = 'https://www.youtube.com/shorts/D4u-BW_YgPA';
+
+        $post = app(Post::class);
+
+        $post->setOriginalUrl($originalYouTubeUrl);
+
+        $this->assertEquals($this->expectedShortsYoutubeUrl, $post->original_url);
+    }
+
+    /**
+     * Tests if a shorts YouTube video url generated from a share button gets parsed correctly
+     * (https://youtube.com/shorts/D4u-BW_YgPA?si=YQtfO_-Gd5iE9doW)
+     *
+     * @test
+     */
+    public function set_original_url_sets_correct_url_with_shorts_share_youtube_video_url()
+    {
+        $originalShareYouTubeUrl = 'https://youtube.com/shorts/D4u-BW_YgPA?si=YQtfO_-Gd5iE9doW';
+
+        $post = app(Post::class);
+
+        $post->setOriginalUrl($originalShareYouTubeUrl);
+
+        $this->assertEquals($this->expectedShortsYoutubeUrl, $post->original_url);
+    }
+
+    /**
+     * The set original url method should discard all unnecessary url query parameters.
+     * Since YouTube shorts videos do not support timestamps. All url query params should be discarded
+     * (https://www.youtube.com/shorts/D4u-BW_YgPA?t=101s&si=test&foo=bar)
+     *
+     * @test
+     */
+    public function set_original_url_removes_all_unnecessary_url_query_parameters_from_shorts_youtube_url()
+    {
+        $originalYouTubeUrlWithTimestamp = 'https://www.youtube.com/shorts/D4u-BW_YgPA?t=101s&si=test&foo=bar';
+
+        $post = app(Post::class);
+
+        $post->setOriginalUrl($originalYouTubeUrlWithTimestamp);
+
+        $this->assertEquals($this->expectedShortsYoutubeUrl, $post->original_url);
+    }
+
+    /**
+     * The set original url method should discard all unnecessary url query parameters.
+     * Since YouTube shorts videos do not support timestamps. All url query params should be discarded
+     * (https://youtube.com/shorts/D4u-BW_YgPA?si=YwnKxGj4FR7vIKNo&t=101s&foo=bar)
+     *
+     * @test
+     */
+    public function set_original_url_removes_all_unnecessary_url_query_parameters_from_shared_shorts_youtube_url()
+    {
+        $originalYouTubeUrlWithTimestamp = 'https://youtube.com/shorts/D4u-BW_YgPA?si=YwnKxGj4FR7vIKNo&t=101s&foo=bar';
+
+        $post = app(Post::class);
+
+        $post->setOriginalUrl($originalYouTubeUrlWithTimestamp);
+
+        $this->assertEquals($this->expectedShortsYoutubeUrl, $post->original_url);
+    }
+
+    /**
+     * Tests if a YouTube URL starting without a "www." gets "www."
+     * (https://youtube.com/shorts/D4u-BW_YgPA)
+     *
+     * @test
+     */
+    public function set_original_url_adds_www_prefix_to_url(): void
+    {
+        $originalYouTubeUrl = 'https://youtube.com/shorts/D4u-BW_YgPA';
+
+        $post = app(Post::class);
+
+        $post->setOriginalUrl($originalYouTubeUrl);
+
+        $this->assertTrue(str_starts_with($post->original_url, 'https://www.'));
     }
 }


### PR DESCRIPTION
* Update YouTube URL parsing in Post model

The URL validation pattern has been updated to also match YouTube URLs without "www." Additionally, if the parsed URL host doesn't start with "www", it's now prefixed before further processing. This ensures accurate and consistent URL handling across the Post model.

* Add tests for parsing and formatting YouTube shorts URLs

We've introduced new unit tests to ensure that YouTube shorts URLs are correctly parsed and formatted by the setOriginalUrl method. This includes discarding unnecessary URL parameters and adding the "www." prefix if it's missing.

---------