### PR TITLE
Fix youtube share url without query params (#17)

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -58,6 +58,7 @@ class Post extends Model
     public static function getYoutubeUrl(string $url): string|null
     {
         $parsedUrl = parse_url($url);
+        $queryParameters = [];
 
         if (array_key_exists('query', $parsedUrl)) {
             $urlQueries = $parsedUrl['query'];

--- a/tests/Unit/Post/SetMediaTypeTest.php
+++ b/tests/Unit/Post/SetMediaTypeTest.php
@@ -27,7 +27,7 @@ class SetMediaTypeTest extends TestCase
     }
 
     /**
-     * Tests if the model field 'type' gets set to tiktok
+     * Tests if the model field 'type' gets set to TikTok
      * (https://www.youtube.com/watch?v=0jYQ58e1yXs)
      *
      * @test

--- a/tests/Unit/Post/SetOriginalUrlTest.php
+++ b/tests/Unit/Post/SetOriginalUrlTest.php
@@ -29,6 +29,23 @@ class SetOriginalUrlTest extends TestCase
     }
 
     /**
+     * Tests if a YouTube video url generated from a mobile 'copy link' button gets parsed correctly
+     * (https://youtu.be/0jYQ58e1yXs)
+     *
+     * @test
+     */
+    public function set_original_url_sets_correct_url_with_mobile_copy_link_youtube_video_url()
+    {
+        $originalShareYouTubeUrl = 'https://youtu.be/0jYQ58e1yXs';
+
+        $post = app(Post::class);
+
+        $post->setOriginalUrl($originalShareYouTubeUrl);
+
+        $this->assertEquals($this->expectedNormalYoutubeUrl, $post->original_url);
+    }
+
+    /**
      * Tests if a YouTube video url generated from a share button gets parsed correctly
      * (https://youtu.be/0jYQ58e1yXs?si=webTBvCxRVKMMjav)
      *


### PR DESCRIPTION
* fix typo in TikTok

* support empty query parameters on share url